### PR TITLE
Add d10 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2025-09-11
+### Added
+- D10 compatibility
+
 ## [1.3.1] - 2021-05-11
 ### Added
 - Add dead letter queue UI integration

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "drupal/core": "^8.5 || ^9.0"
+        "drupal/core": "^9.0 || ^10.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.0",

--- a/modules/wmsubscription_dead_letter_queue/wmsubscription_dead_letter_queue.info.yml
+++ b/modules/wmsubscription_dead_letter_queue/wmsubscription_dead_letter_queue.info.yml
@@ -2,9 +2,7 @@ name: wmsubscription_dead_letter_queue
 type: module
 description: Adds support for the Dead Letter Queue module to wmsubscription
 package: Wieni
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
-    - drupal:system (>= 8.5)
     - dead_letter_queue
     - wmsubscription

--- a/modules/wmsubscription_dead_letter_queue_ui/wmsubscription_dead_letter_queue_ui.info.yml
+++ b/modules/wmsubscription_dead_letter_queue_ui/wmsubscription_dead_letter_queue_ui.info.yml
@@ -2,9 +2,7 @@ name: wmsubscription_dead_letter_queue_ui
 type: module
 description: Adds support for the Dead Letter Queue UI module to wmsubscription
 package: Wieni
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
-    - drupal:system (>= 8.5)
     - dead_letter_queue_ui
     - wmsubscription

--- a/src/Event/SubscriberEventBase.php
+++ b/src/Event/SubscriberEventBase.php
@@ -4,7 +4,7 @@ namespace Drupal\wmsubscription\Event;
 
 use Drupal\wmsubscription\ListInterface;
 use Drupal\wmsubscription\PayloadInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 abstract class SubscriberEventBase extends Event
 {

--- a/wmsubscription.info.yml
+++ b/wmsubscription.info.yml
@@ -2,7 +2,4 @@ name: wmsubscription
 type: module
 description: Provides a common interface for managing email marketing platform subscriptions.
 package: Wieni
-core: 8.x
-core_version_requirement: ^8 || ^9
-dependencies:
-    - drupal:system (>= 8.5)
+core_version_requirement: ^9 || ^10


### PR DESCRIPTION
## Description

- modules/contrib/wmsubscription/src/Event/SubscriberEventBase.php	9	Class Drupal\wmsubscription\Event\SubscriberEventBase extends deprecated class Symfony\Component\EventDispatcher\Event: since Symfony 4.3, use "Symfony\Contracts\EventDispatcher\Event" instead
- modules/contrib/wmsubscription/wmsubscription.info.yml	6	Value of core_version_requirement: ^8 || ^9 is not compatible with the next major version of Drupal core. See https://drupal.org/node/3070687.
- modules/contrib/wmsubscription/modules/wmsubscription_dead_letter_queue_ui/wmsubscription_dead_letter_queue_ui.info.yml	6	Value of core_version_requirement: ^8 || ^9 is not compatible with the next major version of Drupal core. See https://drupal.org/node/3070687.
- modules/contrib/wmsubscription/modules/wmsubscription_dead_letter_queue/wmsubscription_dead_letter_queue.info.yml	6	Value of core_version_requirement: ^8 || ^9 is not compatible with the next major version of Drupal core. See https://drupal.org/node/3070687.
- modules/contrib/wmsubscription/composer.json	1	The drupal/core requirement is not compatible with the next major version of Drupal. Either remove it or update it to be compatible. See https://www.drupal.org/docs/develop/using-composer/add-a-composerjson-file#core-compatibility.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
